### PR TITLE
Add Monte Carlo savings and expense simulator

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1,1 +1,187 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Savings & Expense Monte Carlo Simulator</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 20px;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 10px;
+      }
+      th,
+      td {
+        border: 1px solid #ccc;
+        padding: 4px;
+        text-align: left;
+      }
+      th {
+        background: #f0f0f0;
+      }
+      input,
+      select {
+        width: 100%;
+      }
+      button {
+        margin: 5px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Savings & Expense Monte Carlo Simulator</h1>
+    <div>
+      <label
+        >Simulation Years: <input type="number" id="years" value="30"
+      /></label>
+      <label>Simulations: <input type="number" id="sims" value="100" /></label>
+      <button id="add-investment">Add Investment</button>
+      <button id="add-expense">Add Expense</button>
+      <button id="run">Run Simulation</button>
+    </div>
 
+    <table id="bins-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Initial</th>
+          <th>Min Return %</th>
+          <th>Max Return %</th>
+          <th>Contribution</th>
+          <th>Frequency</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <canvas id="chart" width="800" height="400"></canvas>
+
+    <script>
+      const binsBody = document.querySelector("#bins-table tbody");
+      document.getElementById("add-investment").onclick = () =>
+        addRow("investment");
+      document.getElementById("add-expense").onclick = () => addRow("expense");
+      document.getElementById("run").onclick = runSimulation;
+
+      function addRow(type) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+        <td><input type="text" value="${type.charAt(0).toUpperCase() + type.slice(1)} ${binsBody.children.length + 1}" /></td>
+        <td>${type}</td>
+        <td><input type="number" value="0" /></td>
+        <td><input type="number" value="0" ${type === "investment" ? "" : "disabled"} /></td>
+        <td><input type="number" value="0" ${type === "investment" ? "" : "disabled"} /></td>
+        <td><input type="number" value="0" /></td>
+        <td>
+          <select>
+            <option value="monthly">Monthly</option>
+            <option value="weekly">Weekly</option>
+            <option value="annual">Annual</option>
+          </select>
+        </td>
+        <td><button class="remove">X</button></td>
+      `;
+        tr.dataset.type = type;
+        tr.querySelector(".remove").onclick = () => tr.remove();
+        binsBody.appendChild(tr);
+      }
+
+      function runSimulation() {
+        const years = parseInt(document.getElementById("years").value);
+        const sims = parseInt(document.getElementById("sims").value);
+        const timePoints = years * 12;
+
+        const rows = Array.from(binsBody.querySelectorAll("tr"));
+        const bins = rows.map((row) => {
+          const cells = row.querySelectorAll("td");
+          return {
+            name: cells[0].querySelector("input").value,
+            type: row.dataset.type,
+            initial: parseFloat(cells[2].querySelector("input").value) || 0,
+            minReturn: cells[3].querySelector("input")
+              ? parseFloat(cells[3].querySelector("input").value) / 100
+              : 0,
+            maxReturn: cells[4].querySelector("input")
+              ? parseFloat(cells[4].querySelector("input").value) / 100
+              : 0,
+            contribution:
+              parseFloat(cells[5].querySelector("input").value) || 0,
+            frequency: cells[6].querySelector("select").value,
+          };
+        });
+
+        let binHistories = bins.map(() => Array(timePoints).fill(0));
+        let aggregateHistory = Array(timePoints).fill(0);
+
+        for (let s = 0; s < sims; s++) {
+          const amounts = bins.map((b) => b.initial);
+          let monthlyReturns = bins.map(() => 0);
+          for (let m = 0; m < timePoints; m++) {
+            if (m % 12 === 0) {
+              monthlyReturns = bins.map((b) => {
+                if (b.type === "investment") {
+                  const annual =
+                    Math.random() * (b.maxReturn - b.minReturn) + b.minReturn;
+                  return Math.pow(1 + annual, 1 / 12) - 1;
+                }
+                return 0;
+              });
+            }
+            let total = 0;
+            bins.forEach((b, i) => {
+              let contrib = 0;
+              if (b.frequency === "monthly") contrib = b.contribution;
+              else if (b.frequency === "weekly") contrib = b.contribution * 4;
+              else if (b.frequency === "annual" && m % 12 === 0)
+                contrib = b.contribution;
+
+              if (b.type === "expense") contrib = -Math.abs(contrib);
+
+              amounts[i] += contrib;
+              amounts[i] *= 1 + monthlyReturns[i];
+
+              binHistories[i][m] += amounts[i];
+              total += amounts[i];
+            });
+            aggregateHistory[m] += total;
+          }
+        }
+
+        binHistories = binHistories.map((hist) => hist.map((v) => v / sims));
+        aggregateHistory = aggregateHistory.map((v) => v / sims);
+
+        const ctx = document.getElementById("chart").getContext("2d");
+        if (window.chart) window.chart.destroy();
+        window.chart = new Chart(ctx, {
+          type: "line",
+          data: {
+            labels: Array.from(
+              { length: timePoints },
+              (_, i) => `Month ${i + 1}`,
+            ),
+            datasets: [
+              ...binHistories.map((hist, i) => ({
+                label: bins[i].name,
+                data: hist,
+              })),
+              { label: "Aggregate", data: aggregateHistory, borderWidth: 2 },
+            ],
+          },
+          options: {
+            scales: { y: { beginAtZero: true } },
+          },
+        });
+      }
+
+      // Add one default investment and expense row
+      addRow("investment");
+      addRow("expense");
+    </script>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Savings_simulator
+# Savings simulator
+
+This repository hosts a small Monte Carlo simulator for savings and expense scenarios.
+
+## Usage
+
+1. Open `Index.html` locally or via GitHub Pages.
+2. Add investment or expense categories and fill in their initial amounts, return ranges, and contribution schedules.
+3. Set the number of years and simulations, then press **Run Simulation** to view average growth for each category and the overall net worth over time.
+
+To host with GitHub Pages, enable Pages for the `main` branch in the repository settings.


### PR DESCRIPTION
## Summary
- Build interactive HTML page for configuring investments or expenses with contributions and return ranges
- Implement Monte Carlo simulation and Chart.js visualization of per-bin and aggregate net worth
- Document GitHub Pages usage and simulator steps in README

## Testing
- `npx prettier -c Index.html README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b5e200e59083228e079cbb487936c3